### PR TITLE
Update versions and add warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Java GRPC bindings for aserto-authorizer
 
+> **Warning**
+>
+> **0.20.5** is the latest version published to maven central. Versions starting with 1.0.z have been removed from maven central and are no longer available for download.
+
 
 ## Requirements
 - golang 1.19

--- a/examples/README.md
+++ b/examples/README.md
@@ -123,5 +123,5 @@ Update the `examples/.env` file with the `Tenant ID` and `Authorizer API key` va
 To run the examples, execute:
 
 ```bash
-java -jar target/examples-1.0.0-SNAPSHOT-shaded.jar
+java -jar target/examples-1.0.0-shaded.jar
 ```

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>com.aserto</groupId>
     <artifactId>examples</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <properties>
-        <maven.compiler.source>19</maven.compiler.source>
-        <maven.compiler.target>19</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.aserto</groupId>
             <artifactId>java-authorizer</artifactId>
-            <version>1.0.1</version>
+            <version>0.20.5</version>
         </dependency>
 
         <!-- Used to load .env files -->


### PR DESCRIPTION
Versions starting with 1.0.z have been removed from maven central, but they still appear in the search https://central.sonatype.com/artifact/com.aserto/java-authorizer
If a user tries to use 1.0.z version, they will get an error, because the artifact is not available for download. In order to reduce the confusion I added a warning message in the readme.