### PR TITLE
Bump gRPC version to fix Http2Headers.isEmpty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <grpc.version>1.59.0</grpc.version>
+        <grpc.version>1.59.1</grpc.version>
         <protobuf.version>3.25.0</protobuf.version>
         <tomcat.annotation.api.version>6.0.53</tomcat.annotation.api.version>
     </properties>


### PR DESCRIPTION
While trying to implement Topaz into Spring using the [aserto-spring middleware](https://github.com/aserto-dev/aserto-spring) (version 0.0.12). We used the example [docker-compose](https://www.topaz.sh/docs/deployment/docker-compose) project to get started quickly and followed the aserto-spring example documentation. However, @haftoe and I ran into the following error when performing the `authz/is` check: `Is call failed [UNKNOWN]`. 

We first set the logging level to trace for the Docker containers and after some initial troubleshooting, we encountered the problem described above. Afterwards, we tried to create our own Spring Beans with the [Aserto Java client](https://github.com/aserto-dev/aserto-java) and created the following stacktrace:

```
java.lang.UnsupportedOperationException: null
	at io.grpc.netty.AbstractHttp2Headers.isEmpty(AbstractHttp2Headers.java:40) ~[grpc-netty-1.53.0.jar:1.53.0]
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:419) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:352) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.Http2InboundFrameLogger$1.onHeadersRead(Http2InboundFrameLogger.java:56) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:476) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:484) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:253) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:159) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.Http2InboundFrameLogger.readFrame(Http2InboundFrameLogger.java:41) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:188) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:393) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:453) ~[netty-codec-http2-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1475) ~[netty-handler-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1338) ~[netty-handler-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1387) ~[netty-handler-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) ~[netty-codec-4.1.101.Final.jar:4.1.101.Final]
....
```
This led us to a recent [closed issue](https://github.com/grpc/grpc-java/pull/10663) from grpc-java, which meant that the minor version needed to be bumped. Our temporary solution for our Spring Boot application was to manually exclude the dependencies in `aserto-spring`.

```xml
<dependency>
	<groupId>com.aserto</groupId>
	<artifactId>aserto-spring</artifactId>
	<version>0.0.12</version>
	<exclusions>
		<exclusion>
			<groupId>io.grpc</groupId>
			<artifactId>grpc-netty</artifactId>
		</exclusion>
		<exclusion>
			<groupId>io.grpc</groupId>
			<artifactId>grpc-api</artifactId>
		</exclusion>
	</exclusions>
</dependency>

<dependency>
	<groupId>io.grpc</groupId>
	<artifactId>grpc-netty</artifactId>
	<version>1.59.1</version>
</dependency>

<dependency>
	<groupId>io.grpc</groupId>
	<artifactId>grpc-api</artifactId>
	<version>1.59.1</version>
</dependency>
```

